### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         stages:
           - pre-commit
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.16.1'
+    rev: 'v1.17.0'
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
This PR was created automatically by the pre-commit autoupdate workflow.
It updates the pre-commit hooks to their latest versions.